### PR TITLE
Create alldadataConfig.class.php

### DIFF
--- a/lib/config/alldadataConfig.class.php
+++ b/lib/config/alldadataConfig.class.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Application config class
+ *
+ * @license MIT
+ */
+ 
+ class alldadataConfig extends waAppConfig
+ {
+    /**
+     * Returns new API instance
+     */
+    public function getApiClient()
+    {
+        return new alldadataApi();
+    }
+ }


### PR DESCRIPTION
Чтоб в приложении/плагине было удобно использовать
```php
$dadata = wa('alldadata')->getApiClient();
```
вместо
```php
wa('alldadata');
$dadata = new alldadataApi();
```
😊